### PR TITLE
Fix circular import: vllm.config -> platforms.cpu -> v1.attention.bac…

### DIFF
--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -1,16 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from __future__ import annotations
+
 import copy
 from dataclasses import dataclass, fields, replace
 from enum import IntEnum
 from math import prod
+from typing import TYPE_CHECKING
 
 import torch
 from typing_extensions import Self
 
-from vllm.config import VllmConfig
 from vllm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import get_dtype_size
 


### PR DESCRIPTION
…kend -> v1.kv_cache_interface -> vllm.config

Move the `VllmConfig` import in `vllm/v1/kv_cache_interface.py` behind `TYPE_CHECKING` and add `from __future__ import annotations` so that type annotations are evaluated lazily. `VllmConfig` is only used as a type annotation in method signatures, never at runtime, so this is safe and breaks the circular import chain that caused:

  ImportError: cannot import name 'VllmConfig' from partially
  initialized module 'vllm.config'

Co-authored-by: Claude
Signed-off-by: sagformas <sagformas@epdcenter.es>

https://claude.ai/code/session_01Jk8rxBj2cJ15KKgnC59Mei

<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

