### PR TITLE
Port LCM-padding fallback from #40128 into unify_kv_cache_spec_page_size

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -4,6 +4,7 @@
 
 import copy
 import hashlib
+import math
 import os
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
@@ -930,8 +931,6 @@ def unify_kv_cache_spec_page_size(
     Returns:
         The updated KVCacheSpec with the same page_size_bytes.
     """
-    import math
-
     page_sizes = {layer.page_size_bytes for layer in kv_cache_spec.values()}
     if len(page_sizes) <= 1:
         # All layers have the same page size, no need to unify.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -917,8 +917,12 @@ def unify_kv_cache_spec_page_size(
     """
     Unify the page size of the given KVCacheSpec. If the page size of all layers
     are the same, return the original KVCacheSpec. If not same, unify the page
-    size by increasing the block size of layers with smaller page size. Raise
-    NotImplementedError if failed to unify the page size.
+    size by increasing the block size of layers with smaller page size.
+
+    For hybrid models (e.g. TurboQuant + DeltaNet/Mamba), page sizes may not
+    be naturally divisible. In this case, the largest page size is padded UP
+    to the nearest multiple of all smaller page sizes using page_size_padded.
+    Memory overhead is typically <0.1%.
 
     Args:
         kv_cache_spec: The KVCacheSpec of each attention layer in the model
@@ -926,27 +930,67 @@ def unify_kv_cache_spec_page_size(
     Returns:
         The updated KVCacheSpec with the same page_size_bytes.
     """
+    import math
+
     page_sizes = {layer.page_size_bytes for layer in kv_cache_spec.values()}
     if len(page_sizes) <= 1:
         # All layers have the same page size, no need to unify.
         return kv_cache_spec
 
     max_page_size = max(page_sizes)
+
+    # Check if all smaller pages divide max evenly (fast path)
+    smaller_sizes = sorted(ps for ps in page_sizes if ps < max_page_size)
+    all_divide = all(max_page_size % ps == 0 for ps in smaller_sizes)
+
+    if all_divide:
+        target_page_size = max_page_size
+    else:
+        # Hybrid model: page sizes not naturally divisible.
+        # Pad max_page_size UP to nearest multiple of LCM of smaller sizes.
+        smaller_lcm = math.lcm(*smaller_sizes)
+        target_page_size = (
+            (max_page_size + smaller_lcm - 1) // smaller_lcm
+        ) * smaller_lcm
+        logger.info(
+            "Page size unification: padding max %d -> %d (LCM of smaller = %d, "
+            "overhead %.3f%%)",
+            max_page_size,
+            target_page_size,
+            smaller_lcm,
+            (target_page_size - max_page_size) / max_page_size * 100,
+        )
+
     new_kv_cache_spec = {}
     for layer_name, layer_spec in kv_cache_spec.items():
-        if layer_spec.page_size_bytes == max_page_size:
+        layer_page = layer_spec.page_size_bytes
+        if layer_page == target_page_size:
             new_kv_cache_spec[layer_name] = layer_spec
-        else:
-            layer_page_size = layer_spec.page_size_bytes
-            if max_page_size % layer_page_size != 0:
-                raise NotImplementedError(
-                    "The page size of the layer is not divisible by the "
-                    "maximum page size. Cannot unify by adjusting block_size."
-                )
-            ratio = max_page_size // layer_page_size
+        elif layer_page < target_page_size and target_page_size % layer_page == 0:
+            # Scale up block_size so page matches target
+            ratio = target_page_size // layer_page
             new_block_size = layer_spec.block_size * ratio
             new_spec = replace(layer_spec, block_size=new_block_size)
-            assert new_spec.page_size_bytes == max_page_size
+            assert new_spec.page_size_bytes == target_page_size, (
+                f"Page size mismatch after block_size adjust: "
+                f"{new_spec.page_size_bytes} != {target_page_size}"
+            )
+            new_kv_cache_spec[layer_name] = new_spec
+        else:
+            # Layer had the original max page size but target was padded up.
+            # Use page_size_padded to pad this layer to target.
+            try:
+                new_spec = replace(layer_spec, page_size_padded=target_page_size)
+            except TypeError as e:
+                raise NotImplementedError(
+                    f"Cannot pad page size for {type(layer_spec).__name__}: "
+                    f"page_size_padded not supported. "
+                    f"Layer page={layer_page}, target={target_page_size}"
+                ) from e
+            assert new_spec.page_size_bytes == target_page_size, (
+                f"Page size mismatch after padding: "
+                f"{new_spec.page_size_bytes} != {target_page_size}"
+            )
             new_kv_cache_spec[layer_name] = new_spec
     return new_kv_cache_spec
 


### PR DESCRIPTION
## What

Ports the LCM-padding logic from [vllm-project/vllm#40128](https://github.com/vllm-project/vllm/pull/40128) (by @Sandermage) into this branch as a safety net for hybrid TurboQuant models whose attention and Mamba page sizes still mismatch after `_align_hybrid_block_size`.

## Why not a duplicate

- #40128 standalone does **not** subsume #39931 — #39931 is the umbrella hybrid-TQ PR that actually makes hybrid models viable.
- #40128 author (@Sandermage) explicitly [offered to close #40128](https://github.com/vllm-project/vllm/pull/40128#issuecomment-) if the LCM fallback is folded into this PR.
- This PR is that fold. One file, one function, ~40 net lines.

## The fix

Today `unify_kv_cache_spec_page_size(...)` in `vllm/v1/core/kv_cache_utils.py` raises `NotImplementedError` whenever the smaller page size doesn't evenly divide the largest. On hybrid models where `_align_hybrid_block_size` can't fully equalize (TurboQuant attention packed K|V with unusual `head_dim` vs. Mamba/DeltaNet state), this crashes model init.

Fast path is unchanged: if every smaller page size already divides the max, behavior is identical to today.

New slow path: compute `LCM` of the smaller sizes, round `max_page_size` up to the next multiple, and use the existing `page_size_padded` field (already present on `AttentionSpec` and `MambaSpec` on main) to pad the layer that held the original max. Overhead is logged at INFO and in practice sits well under 0.1 %.

## Test commands + results

### 1. Direct probe of the LCM branch (inside the docker container, with the overlaid patch)

```python
attn = FullAttentionSpec(block_size=1, num_kv_heads=1, head_size=194, dtype=torch.bfloat16)
mamba = MambaSpec(block_size=1, shapes=((3162112,),), dtypes=(torch.float32,))
# attn.page_size_bytes = 776   mamba.page_size_bytes = 12_648_448   not divisible
out = unify_kv_cache_spec_page_size({"attn0": attn, "mamba0": mamba})
```

Output:

```
INFO kv_cache_utils.py:955 Page size unification: padding max 12648448 -> 12648800
     (LCM of smaller = 776, overhead 0.003%)
attn0  -> 12648800  block_size=16300  pad=None
mamba0 -> 12648800  block_size=1      pad=12648800
UNIFIED OK  target=12648800  overhead=0.0028%
```

Confirms: slow path fires, both specs end at a single unified `page_size_bytes`, attention got block-scaled, Mamba got `page_size_padded`.

### 2. End-to-end serve: hybrid MoE + TurboQuant k8v4, 64 k context

Hardware: RTX 5090 (sm_120, 32 GiB), CUDA 13, vllm `cu130-nightly` image with this branch's four files overlaid. `--enforce-eager` only because the cudagraph-capture profiler spikes on a 32 GiB card; runtime KV fits fine.

```
docker compose up
  --model=RedHatAI/Qwen3.6-35B-A3B-NVFP4
  --kv-cache-dtype=turboquant_k8v4
  --max-model-len=65536
  --max-num-seqs=4
  --gpu-memory-utilization=0.90
  --enforce-eager
```

Key log lines:

```
[config.py:195]  TQ hybrid: full-attention layers [3, 7, 11, 15, 19, 23, 27, 31, 35, 39]
[cuda.py:368]    Using TURBOQUANT attention backend out of potential backends: ['TURBOQUANT']
[default_loader.py:384] Loading weights took 7.11 seconds
[gpu_model_runner.py:4837] Model loading took 21.88 GiB memory
[interface.py:639] Setting attention block size to 2768 tokens to ensure that attention page size is >= mamba page size.
[interface.py:663] Padding mamba page size by 0.08% to ensure that mamba page size and attention page size are exactly equal.
[kv_cache_utils.py:1363] GPU KV cache size: 146,704 tokens
[api_server.py:602] Starting vLLM server on http://0.0.0.0:8000
INFO: Application startup complete.
```

Completion request (greedy, 24 tokens):

```json
{"choices":[{"text":" a large context kv cache test.\n\n<think>\nHere's a thinking process:\n\n1.  **Analyze User","finish_reason":"length"}]}
```

On this particular model, `_align_hybrid_block_size` already equalizes pages (0.08 % pad), so `unify_kv_cache_spec_page_size` short-circuits at `len(page_sizes) <= 1` and the new slow path is a silent safety net. Test #1 exercises the slow path directly to prove it works.

## Accountability / AI-assist disclosure (per AGENTS.md)

- I (the human submitter, @jhsmith409) reviewed every changed line end-to-end and ran both tests above.
- Code was ported and docker test harness was drafted with assistance from Claude (Anthropic); attribution is in the commit trailer.
- Original LCM logic and rationale are from @Sandermage (#40128); my ports: lint-conform split of one long line, `raise ... from e` on the `TypeError` guard, line-split `logger.info` args.

Happy to rebase / reword / drop the AI-assist trailer on request.