### PR TITLE
fix(turboquant_attn): eliminate peak-memory spike in _continuation_prefill

### DIFF
--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -701,23 +701,29 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
             num_warps=4,
         )
 
-        # Inverse-rotate MSE keys back to original space
+        # Inverse-rotate MSE keys back to original space.
+        # Rotate in FP16 (not FP32) to avoid a ~cached_len*Hk*D*4 B transient
+        # spike at long context. The FP32 intermediate doubled peak memory for
+        # no accuracy benefit: the rotation is applied to keys that were already
+        # reconstructed from 3-4 bit MSE indices, and any FP16 roundoff is
+        # negligible vs that quantization error.
         if not self.tq_config.key_fp8:
-            k_flat = k_cached[0, :, :cached_len, :].reshape(-1, D).float()
-            k_flat = k_flat @ Pi
+            Pi_half = Pi.to(torch.float16) if Pi.dtype != torch.float16 else Pi
+            k_flat = k_cached[0, :, :cached_len, :].reshape(-1, D)  # (Hk*cached_len, D) FP16
+            k_flat = k_flat @ Pi_half  # FP16 matmul, single transient output
             k_cached_trim = (
-                k_flat.to(torch.float16).reshape(Hk, cached_len, D).transpose(0, 1)
-            )  # (cached_len, Hk, D)
+                k_flat.reshape(Hk, cached_len, D).transpose(0, 1)
+            )  # (cached_len, Hk, D) — non-contiguous view
         else:
-            k_cached_trim = (
-                k_cached[0, :, :cached_len, :].transpose(0, 1).contiguous()
-            )  # (cached_len, Hk, D)
+            k_cached_trim = k_cached[0, :, :cached_len, :].transpose(0, 1)
+            # (cached_len, Hk, D) — non-contiguous view
 
-        v_cached_trim = (
-            v_cached[0, :, :cached_len, :].transpose(0, 1).contiguous()
-        )  # (cached_len, Hk, D)
+        v_cached_trim = v_cached[0, :, :cached_len, :].transpose(0, 1)
+        # (cached_len, Hk, D) — non-contiguous view
 
-        # Concatenate cached + current chunk K/V (match query dtype)
+        # torch.cat already produces a contiguous output, so the upstream
+        # .contiguous() materializations previously here were redundant and
+        # doubled peak memory at long context.
         qdtype = query.dtype
         k_full = torch.cat([k_cached_trim.to(qdtype), key_chunk], dim=0)
         v_full = torch.cat([v_cached_trim.to(qdtype), val_chunk], dim=0)


### PR DESCRIPTION
Fixes vllm-project/vllm#40420 — long-prefill OOM in `_continuation_prefill` that crashes the entire engine (not just the request) at ~185K actual tokens on a 32 GiB card, well below the configured `--max-model-len=262144`.

### Root cause

`_continuation_prefill` has two redundant peak-memory materializations at long context:

1. **FP32 intermediate for the inverse Hadamard rotation.** `k_cached[..].reshape(-1, D).float() @ Pi` allocates a `cached_len*Hk*D*4 B` FP32 tensor, then `.to(torch.float16)` allocates a FP16 copy. The FP32 widening serves no accuracy purpose — keys were reconstructed from 3-4 bit MSE indices, so FP16 roundoff on the rotation is orders of magnitude below the quantization noise already in the cache.
2. **Redundant `.contiguous()` on transposed K/V views before `torch.cat`.** `torch.cat` produces a contiguous output regardless of input contiguity, so the upstream `.contiguous()` doubled the transient footprint for no reason.

### Changes

Two small, local changes to `_continuation_prefill`. No API changes, no new persistent state, no change to kernel interfaces. 18 insertions / 12 deletions, single file.

### Verification

RTX 5090 (32 GiB) + `cyankiwi/Qwen3.6-35B-A3B-AWQ-4bit` + `--kv-cache-dtype=turboquant_4bit_nc --max-model-len=262144 --gpu-memory-utilization=0.87`:

| target tokens | actual prompt tokens | before | after |
|---------------|---------------------|--------|-------|
| 230,000 | 184,079 | PASS | PASS |
| 245,000 | ~196,000 | **CRASH** | PASS |
| 255,000 | 204,081 | **CRASH** | PASS |
| 260,000 | 208,082 | **CRASH** | PASS |

New ceiling covers the full advertised `max-model-len`. NIAH retrieval accuracy (45/45 across 8k/32k/128k/160k/192k) is unchanged on the fixed path.

### Scope

Does not touch the Triton dequant kernel, the decode path, or the cache layout — purely the PyTorch glue between dequant and flash_attn_varlen_func. Should be safe to merge into `feature/hybrid_turboquant` independently of the other outstanding PRs in the stack.